### PR TITLE
:sparkles: engine::sink is no longer a singleton

### DIFF
--- a/awe/CMakeLists.txt
+++ b/awe/CMakeLists.txt
@@ -5,7 +5,6 @@ set(${PROJECT_NAME}_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include"
 	CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)
 
 add_library(${PROJECT_NAME} STATIC
-	"source/dialogue.cpp"
 	"source/bank.cpp"
 	"source/tile.cpp"
 	"source/unit.cpp"

--- a/awe/include/bank.hpp
+++ b/awe/include/bank.hpp
@@ -87,11 +87,10 @@ namespace awe {
 		 *                given but with \c "Bank" appended, and the single global
 		 *                property of this bank type will be called the given name,
 		 *                but in lowercase.
-		 * @param logName Name given for to this bank object in the log file.
-		 *                Defaults to "bank."
+		 * @param data    The data to initialise the logger object with.
 		 */
 		bank(const std::shared_ptr<engine::scripts>& scripts,
-			const std::string& name, const std::string& logName = "bank") noexcept;
+			const std::string& name, const engine::logger::data& data) noexcept;
 
 		/**
 		 * The type of container used to store bank values internally.
@@ -1536,9 +1535,11 @@ namespace awe {
 		 *          with a unit's weapons.
 		 * @param   weaponBank A reference to the weapons bank to pull information
 		 *                     from.
+		 * @param   sink       Pointer to the sink which JSON objects created in
+		 *                     this method will output to.
 		 */
-		void updateWeapons(const awe::bank<awe::weapon>& weaponBank) const
-			noexcept;
+		void updateWeapons(const awe::bank<awe::weapon>& weaponBank,
+			const std::shared_ptr<engine::sink>& sink) const noexcept;
 
 		/**
 		 * Updates \c _picturesTurnOrder and \c _unitsTurnOrder by copying over the
@@ -1799,12 +1800,15 @@ namespace awe {
 	 * @param terrainBank  The \c terrain bank to pull the pointers from.
 	 * @param weaponBank   The \c weapon bank to pull the pointers from.
 	 * @param countryBank  The \c country bank to pull turn order IDs from.
+	 * @param sink         Pointer to the sink which JSON objects created in this
+	 *                     function will output to.
 	 */
 	void updateUnitTypeBank(awe::bank<awe::unit_type>& unitBank,
 		const awe::bank<awe::movement_type>& movementBank,
 		const awe::bank<awe::terrain>& terrainBank,
 		const awe::bank<awe::weapon>& weaponBank,
-		const awe::bank<awe::country>& countryBank) noexcept;
+		const awe::bank<awe::country>& countryBank,
+		const std::shared_ptr<engine::sink>& sink) noexcept;
 
 	/**
 	 * Checks an entire bank of countries to ensure each country's turn order ID is

--- a/awe/include/engine.hpp
+++ b/awe/include/engine.hpp
@@ -50,11 +50,10 @@ namespace awe {
 		/**
 		 * Initialises the internal logger object.
 		 * Also seeds the psuedo random number sequence generator.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "engine."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		game_engine(const std::string& name = "engine") noexcept;
+		game_engine(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Executes the game based on given game data.

--- a/awe/include/map.hpp
+++ b/awe/include/map.hpp
@@ -125,11 +125,10 @@ namespace awe {
 
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "map."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		map(const std::string& name = "map") noexcept;
+		map(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Initialises this object with \c bank pointers.
@@ -142,16 +141,14 @@ namespace awe {
 		 *                   reading unit type IDs from map files.
 		 * @param commanders Information on the commanders to search through when
 		 *                   reading CO IDs from map files.
-		 * @param name       The name to give this particular instantiation within
-		 *                   the log file. Defaults to "map."
+		 * @param data       The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
 		map(const std::shared_ptr<awe::bank<awe::country>>& countries,
 			const std::shared_ptr<awe::bank<awe::tile_type>>& tiles,
 			const std::shared_ptr<awe::bank<awe::unit_type>>& units,
 			const std::shared_ptr<awe::bank<awe::commander>>& commanders,
-			const std::string& name = "map")
-			noexcept;
+			const engine::logger::data& data) noexcept;
 
 		/**
 		 * Replaces the state of this object with that given in the binary file.

--- a/awe/include/tile.hpp
+++ b/awe/include/tile.hpp
@@ -46,12 +46,14 @@ namespace awe {
 
 		/**
 		 * Construct a new tile with a given type.
+		 * @param data  Data used to initialise the sprite's logger object.
 		 * @param type  The type of tile to create.
 		 *              \c nullptr if you don't wish to provide a type at this
 		 *              time.
 		 * @param sheet Pointer to the spritesheet to use with this tile.
 		 */
-		tile(const std::shared_ptr<const awe::tile_type>& type = nullptr,
+		tile(const engine::logger::data& data,
+			const std::shared_ptr<const awe::tile_type>& type = nullptr,
 			const std::shared_ptr<sfx::animated_spritesheet>& sheet = nullptr)
 			noexcept;
 

--- a/awe/include/tpp/bank.tpp
+++ b/awe/include/tpp/bank.tpp
@@ -24,8 +24,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 template<typename T>
 awe::bank<T>::bank(const std::shared_ptr<engine::scripts>& scripts,
-	const std::string& name, const std::string& logName) noexcept :
-	_logger(logName), _scripts(scripts), _propertyName(name) {
+	const std::string& name, const engine::logger::data& data) noexcept :
+	engine::json_script({ data.sink, "json_script" }), _logger(data),
+	_scripts(scripts), _propertyName(name) {
 	if (scripts) _scripts->addRegistrant(this);
 }
 
@@ -86,7 +87,7 @@ bool awe::bank<T>::_load(engine::json& j) noexcept {
 	for (auto& i : jj.items()) {
 		// Loop through each object, allowing the template type T to construct its
 		// values based on each object.
-		engine::json input(i.value());
+		engine::json input(i.value(), {_logger.getData().sink, "json"});
 		_bank[i.key()] = std::make_shared<const T>(i.key(), input);
 	}
 	return true;

--- a/awe/include/unit.hpp
+++ b/awe/include/unit.hpp
@@ -54,12 +54,15 @@ namespace awe {
 		 * Creates a new unit.
 		 * @warning \c army \b must hold a valid turn order ID: checks must be
 		 *          carried out outside of this class!
+		 * @param   data  The data used to initialise the animated sprite's logger
+		 *                object.
 		 * @param   type  The type of the unit, which can't be changed.
 		 * @param   army  The army the unit belongs to, which can't be changed.
 		 * @param   sheet Pointer to the spritesheet to use with this unit.
 		 * @param   icons Pointer to the icon spritesheet to use with this unit.
 		 */
-		unit(const std::shared_ptr<const awe::unit_type>& type,
+		unit(const engine::logger::data& data,
+			const std::shared_ptr<const awe::unit_type>& type,
 			const awe::ArmyID army = 0,
 			const std::shared_ptr<sfx::animated_spritesheet>& sheet = nullptr,
 			const std::shared_ptr<sfx::animated_spritesheet>& icons = nullptr)

--- a/awe/source/bank.cpp
+++ b/awe/source/bank.cpp
@@ -44,12 +44,13 @@ void awe::updateUnitTypeBank(awe::bank<awe::unit_type>& unitBank,
 	const awe::bank<awe::movement_type>& movementBank,
 	const awe::bank<awe::terrain>& terrainBank,
 	const awe::bank<awe::weapon>& weaponBank,
-	const awe::bank<awe::country>& countryBank) noexcept {
+	const awe::bank<awe::country>& countryBank,
+	const std::shared_ptr<engine::sink>& sink) noexcept {
 	for (const auto& unit : unitBank) {
 		unit.second->updateMovementType(movementBank);
 		unit.second->updateUnitTypes(unitBank);
 		unit.second->updateTerrainTypes(terrainBank);
-		unit.second->updateWeapons(weaponBank);
+		unit.second->updateWeapons(weaponBank, sink);
 		unit.second->updateSpriteMaps(countryBank);
 	}
 }
@@ -321,8 +322,8 @@ void updateJJNew(nlohmann::ordered_json& jjNew,
 		}
 	}
 }
-void awe::unit_type::updateWeapons(const awe::bank<awe::weapon>& weaponBank) const
-noexcept {
+void awe::unit_type::updateWeapons(const awe::bank<awe::weapon>& weaponBank,
+	const std::shared_ptr<engine::sink>& sink) const noexcept {
 	_weapons.clear();
 	for (const auto weapon : _baseWeapons) {
 		if (weaponBank.contains(weapon.first)) {
@@ -346,7 +347,7 @@ noexcept {
 			// For hiddenunits, the override will completely replace the base
 			// object, if an override is given. update() does this for us.
 			const auto newWeapon = std::make_shared<const awe::weapon>(
-				weapon.first, engine::json(jjNew));
+				weapon.first, engine::json(jjNew, {sink, "json"}));
 			_weapons.emplace(weapon.first, newWeapon);
 		}
 	}

--- a/awe/source/map.cpp
+++ b/awe/source/map.cpp
@@ -599,7 +599,8 @@ void awe::map::Register(asIScriptEngine* engine,
 	}
 }
 
-awe::map::map(const std::string& name) noexcept : _logger(name) {
+awe::map::map(const engine::logger::data& data) noexcept : _logger(data),
+	_cursor({ data.sink, data.name + "_cursor_sprite" }) {
 	_initShaders();
 }
 
@@ -607,8 +608,8 @@ awe::map::map(const std::shared_ptr<awe::bank<awe::country>>& countries,
 	const std::shared_ptr<awe::bank<awe::tile_type>>& tiles,
 	const std::shared_ptr<awe::bank<awe::unit_type>>& units,
 	const std::shared_ptr<awe::bank<awe::commander>>& commanders,
-	const std::string& name) noexcept :
-	_logger(name) {
+	const engine::logger::data& data) noexcept : _logger(data),
+	_cursor({data.sink, data.name + "_cursor_sprite"}) {
 	_countries = countries;
 	_tileTypes = tiles;
 	_unitTypes = units;
@@ -706,7 +707,8 @@ void awe::map::setMapSize(const sf::Vector2u& dim,
 	bool mapHasShrunk = (getMapSize().x > dim.x || getMapSize().y > dim.y);
 	_tiles.resize(dim.x);
 	for (std::size_t x = 0; x < dim.x; x++) {
-		_tiles[x].resize(dim.y, { tile, _sheet_tile });
+		_tiles[x].resize(dim.y, { { _logger.getData().sink, "tile" }, tile,
+			_sheet_tile });
 	}
 	if (mapHasShrunk) {
 		// Then, go through all owned tiles in each army and delete those that are
@@ -1140,7 +1142,8 @@ awe::UnitID awe::map::createUnit(const std::shared_ptr<const awe::unit_type>& ty
 			"a new unit. There are too many units allocated!");
 		return 0;
 	}
-	_units.insert({ id, awe::unit(type, army, _sheet_unit, _sheet_icon) });
+	_units.insert({ id, awe::unit({_logger.getData().sink, "unit"}, type, army,
+		_sheet_unit, _sheet_icon) });
 	_armies.at(army).addUnit(id);
 	return id;
 }

--- a/awe/source/tile.cpp
+++ b/awe/source/tile.cpp
@@ -22,9 +22,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "tile.hpp"
 
-awe::tile::tile(const std::shared_ptr<const awe::tile_type>& type,
+awe::tile::tile(const engine::logger::data& data,
+	const std::shared_ptr<const awe::tile_type>& type,
 	const std::shared_ptr<sfx::animated_spritesheet>& sheet) noexcept :
-	_sprite(sheet, "") {
+	_sprite(sheet, "", {data.sink, data.name + "_sprite"}) {
 	setTileType(type);
 }
 

--- a/awe/source/unit.cpp
+++ b/awe/source/unit.cpp
@@ -28,15 +28,19 @@ const sf::Vector2u awe::unit::NO_POSITION(std::numeric_limits<unsigned int>::max
 
 sf::Vector2u awe::unit::NO_POSITION_SCRIPT = awe::unit::NO_POSITION;
 
-awe::unit::unit(const std::shared_ptr<const awe::unit_type>& type,
-	const awe::ArmyID army,
+awe::unit::unit(const engine::logger::data& data,
+	const std::shared_ptr<const awe::unit_type>& type, const awe::ArmyID army,
 	const std::shared_ptr<sfx::animated_spritesheet>& sheet,
 	const std::shared_ptr<sfx::animated_spritesheet>& icons) noexcept :
 	_type(type), _army(army),
-	_sprite(sheet, ((type) ? (type->getUnit(army)) : (""))),
-	_hpIcon(icons, "nohpicon"), _fuelAmmoIcon(icons, "nostatusicon"),
-	_loadedIcon(icons, "nostatusicon"),
-	_capturingHidingIcon(icons, "nostatusicon") {
+	_sprite(sheet, ((type) ? (type->getUnit(army)) : ("")),
+		{data.sink, data.name + "_animated_sprite"}),
+	_hpIcon(icons, "nohpicon", { data.sink, data.name + "_hp_icon" }),
+	_fuelAmmoIcon(icons, "nostatusicon",
+		{ data.sink, data.name + "_fuel_ammo_icon" }),
+	_loadedIcon(icons, "nostatusicon", { data.sink, data.name + "_loaded_icon" }),
+	_capturingHidingIcon(icons, "nostatusicon",
+		{ data.sink, data.name + "_status_icon" }) {
 	// Initialise all ammos.
 	for (std::size_t i = 0, weaponCount = type->getWeaponCount();
 		i < weaponCount; ++i) {

--- a/engine/include/language.hpp
+++ b/engine/include/language.hpp
@@ -146,11 +146,10 @@ namespace engine {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "dictionary."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		language_dictionary(const std::string& name = "dictionary") noexcept;
+		language_dictionary(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Adds a path to a language's string map script.
@@ -278,11 +277,10 @@ namespace engine {
 
 			/**
 			 * Initialises the internal logger object.
-			 * @param name The name to give this particular instantiation
-			 *             within the log file. Defaults to "language."
+			 * @param data The data to initialise the logger object with.
 			 * @sa    \c engine::logger
 			 */
-			language(const std::string& name = "language") noexcept;
+			language(const engine::logger::data& data) noexcept;
 
 			/**
 			 * Accesses a string stored within the string map.

--- a/engine/include/safejson.hpp
+++ b/engine/include/safejson.hpp
@@ -200,21 +200,19 @@ namespace engine {
 
 		/**
 		 * Constructs an empty JSON object.
-		 * @param name The string name of the internal logger object which helps
-		 *             identify this object if it causes an error.
+		 * @param data The data to initialise the logger object with.
 		 */
-		json(const std::string& name = "json") noexcept;
+		json(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Constructs a JSON object from a \c nlohmann one.
 		 * The assignment operator is called in order to achieve this.
 		 * @param jobj The \c nlohmann::ordered_json object to store within this
 		 *             object - this is referred to as the JSON object.
-		 * @param name The string name of the internal logger object which helps
-		 *             identify this object if it causes an error.
+		 * @param data The data to initialise the logger object with.
 		 * @sa    operator=()
 		 */
-		json(const nlohmann::ordered_json& jobj, const std::string& name = "json")
+		json(const nlohmann::ordered_json& jobj, const engine::logger::data& data)
 			noexcept;
 
 		/**
@@ -222,34 +220,45 @@ namespace engine {
 		 * The assignment operator is called in order to achieve this.
 		 * @param jobj The \c nlohmann::ordered_json object to store within this
 		 *             object - this is referred to as the JSON object.
-		 * @param name The string name of the internal logger object which helps
-		 *             identify this object if it causes an error.
+		 * @param data The data to initialise the logger object with.
 		 * @sa    operator=()
 		 */
-		json(nlohmann::ordered_json&& jobj, const std::string& name = "json")
+		json(nlohmann::ordered_json&& jobj, const engine::logger::data& data)
 			noexcept;
 
 		/**
 		 * Copy constructor.
-		 * Copies the JSON itself, but sets up a new logger with a new name.
+		 * Copies the JSON itself, but creates a new logger object.
 		 * @param obj  The object to copy.
-		 * @param name The string name of the internal logger object which helps
-		 *             identify this object if it causes an error.
+		 * @param data The data to initialise the logger object with.
 		 */
-		json(const engine::json& obj, const std::string& name = "json") noexcept;
+		json(const engine::json& obj, const engine::logger::data& data) noexcept;
 
 		/**
 		 * Move constructor.
-		 * Moves the JSON itself, and sets up a new logger with a new name.
+		 * Moves the JSON itself, but creates a new logger object.
 		 * @param obj  The object to move.
-		 * @param name The string name of the internal logger object which helps
-		 *             identify this object if it causes an error.
+		 * @param data The data to initialise the logger object with.
 		 */
-		json(engine::json&& obj, const std::string& name = "json") noexcept;
+		json(engine::json&& obj, const engine::logger::data& data) noexcept;
+
+		/**
+		 * Copy constructor.
+		 * Copies the JSON itself, and the logger object.
+		 * @param obj The object to copy.
+		 */
+		json(const engine::json& obj) noexcept;
+
+		/**
+		 * Move constructor.
+		 * Moves the JSON itself, but copies the logger object.
+		 * @param obj The object to move.
+		 */
+		json(engine::json&& obj) noexcept;
 
 		/**
 		 * Copy assignment operator.
-		 * Copies the internal JSON object.
+		 * Copies the internal JSON object, but does not copy the logger object.
 		 * @param  obj The object to copy over.
 		 * @return Reference to \c this.
 		 */
@@ -257,7 +266,8 @@ namespace engine {
 
 		/**
 		 * Move assignment operator.
-		 * Moves the internal JSON object.
+		 * Moves the internal JSON object, but does not copy or move the logger
+		 * object.
 		 * @param  obj The object to move over.
 		 * @return Reference to \c this.
 		 */
@@ -573,6 +583,12 @@ namespace engine {
 	class json_script : public json_state {
 	public:
 		/**
+		 * Initialises the internal logger object.
+		 * @param data The data to initialise the logger object with.
+		 */
+		json_script(const engine::logger::data& data);
+		
+		/**
 		 * Polymorphic base classes should have virtual destructors.
 		 */
 		virtual ~json_script() noexcept = default;
@@ -710,7 +726,7 @@ namespace engine {
 		/**
 		 * The internal logger object.
 		 */
-		mutable engine::logger _logger = engine::logger("json_script");
+		mutable engine::logger _logger;
 	};
 }
 

--- a/engine/include/script.hpp
+++ b/engine/include/script.hpp
@@ -167,15 +167,14 @@ namespace engine {
 		 * \c registerInterface() method. In addition, loading and building scripts
 		 * relies on the interface being established, so it is carried out
 		 * afterwards using the \c loadScripts() method.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "scripts."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 * @sa    \c engine::scripts::registerInterface()
 		 */
-		scripts(const std::string& name = "scripts") noexcept;
+		scripts(const engine::logger::data& data) noexcept;
 
 		/**
-		 * Releases the sole function context and shuts down the engine.
+		 * Releases all the function contexts and shuts down the engine.
 		 */
 		~scripts() noexcept;
 

--- a/engine/include/tpp/logger.tpp
+++ b/engine/include/tpp/logger.tpp
@@ -24,40 +24,31 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 template<typename... Ts>
 void engine::logger::write(const std::string& line, Ts... values) noexcept {
-	try {
-		_logger->info(line, values...);
-	} catch (const std::exception& e) {
-		boxer::show(e.what(), "Fatal Error!", boxer::Style::Error);
-	}
+	if (_logger) _logger->info(line, values...);
 }
 
 template<typename... Ts>
 void engine::logger::error(const std::string& line, Ts... values) noexcept {
-	try {
-		_logger->error(line, values...);
-	} catch (const std::exception& e) {
-		boxer::show(e.what(), "Fatal Error!", boxer::Style::Error);
-	}
+	if (_logger) _logger->error(line, values...);
 }
 
 template<typename... Ts>
 void engine::logger::warning(const std::string& line, Ts... values) noexcept {
-	try {
-		_logger->warn(line, values...);
-	} catch (const std::exception& e) {
-		boxer::show(e.what(), "Fatal Error!", boxer::Style::Error);
-	}
+	if (_logger) _logger->warn(line, values...);
 }
 
 template<typename... Ts>
 void engine::logger::critical(const std::string& line, Ts... values) noexcept {
+	if (_logger) _logger->critical(line, values...);
 	try {
-		_logger->critical(line, values...);
 		// Produce dialog window.
 		std::string result;
 		fmt::format_to(std::back_inserter(result), line, values...);
 		boxer::show(result.c_str(), "Critical Error!", boxer::Style::Error);
 	} catch (const std::exception& e) {
-		boxer::show(e.what(), "Fatal Error!", boxer::Style::Error);
+		if (_logger) {
+			_logger->critical("Can't produce dialog box for above log: {}",
+				e.what());
+		}
 	}
 }

--- a/engine/include/tpp/safejson.tpp
+++ b/engine/include/tpp/safejson.tpp
@@ -108,8 +108,8 @@ void engine::json::applyMap(std::unordered_map<std::string, T>& dest,
 				_logger.error("The specified JSON object was not homogeneous, "
 					"found a value of data type \"{}\" with key \"{}\" when "
 					"attempting to assign to a map with values of data type "
-					"\"{}\", in the key sequence {}.{}", _getTypeName(item.value()),
-					item.key(), _getTypeName(testDataType),
+					"\"{}\", in the key sequence {}.{}", _getTypeName(
+					item.value()), item.key(), _getTypeName(testDataType),
 					synthesiseKeySequence(keys), ((continueReadingOnTypeError) ?
 						("") : (" Will now stop reading key-value pairs from this "
 							"object.")));

--- a/engine/source/language.cpp
+++ b/engine/source/language.cpp
@@ -45,8 +45,8 @@ std::string engine::expand_string::insert(const std::string& original) {
 	}
 }
 
-engine::language_dictionary::language_dictionary(const std::string& name) noexcept :
-	_logger(name) {}
+engine::language_dictionary::language_dictionary(const engine::logger::data& data)
+	noexcept : engine::json_script({data.sink, "json_script"}), _logger(data) {}
 
 bool engine::language_dictionary::addLanguage(const std::string& id,
 	const std::string& path) noexcept {
@@ -93,7 +93,7 @@ bool engine::language_dictionary::setLanguage(const std::string& id) noexcept {
 		std::unique_ptr<engine::language_dictionary::language> newMap = nullptr;
 		try {
 			newMap = std::make_unique<engine::language_dictionary::language>(
-				"language_" + id
+				engine::logger::data{ _logger.getData().sink, "language_" + id }
 			);
 		} catch (std::bad_alloc& e) {
 			_logger.error("Failed to allocate memory for the string map of "
@@ -150,8 +150,8 @@ bool engine::language_dictionary::_save(nlohmann::ordered_json& j) noexcept {
 	return true;
 }
 
-engine::language_dictionary::language::language(const std::string& name) noexcept :
-	_logger(name) {}
+engine::language_dictionary::language::language(const engine::logger::data& data)
+	noexcept : engine::json_script({ data.sink, "json_script" }), _logger(data) {}
 
 bool engine::language_dictionary::language::_load(engine::json& j) noexcept {
 	_strings.clear();

--- a/engine/source/script.cpp
+++ b/engine/source/script.cpp
@@ -296,14 +296,15 @@ void engine::RegisterFileType(asIScriptEngine* engine,
     }
 }
 
-engine::scripts::scripts(const std::string& name) noexcept : _logger(name) {
+engine::scripts::scripts(const engine::logger::data& data) noexcept : _logger(data)
+    {
     _engine = asCreateScriptEngine();
     if (_engine) {
         // Allocate the documentation generator.
         ScriptDocumentationOptions options;
         options.htmlSafe = false;
         options.projectName = "Computer Wars";
-        std::string filename = name + " Script Interface Documentation.html";
+        std::string filename = data.name + " Script Interface Documentation.html";
         options.outputFile = filename;
         _document = std::make_shared<DocumentationGenerator>(_engine, options);
         // Allocate the script engine.

--- a/main.cpp
+++ b/main.cpp
@@ -68,12 +68,15 @@ int main(int argc, char* argv[]) {
     );
     // Initialise the sink all loggers output to.
 #ifdef COMPUTER_WARS_DEBUG
-    engine::sink::Get("Computer Wars", "CasualYouTuber31", ".", false, false);
+    std::shared_ptr<engine::sink> sink = std::make_shared<engine::sink>(
+        "Computer Wars", "CasualYouTuber31", "", false, nullptr);
 #else
-    engine::sink::Get("Computer Wars", "CasualYouTuber31", ".");
+    std::shared_ptr<engine::sink> sink = std::make_shared<engine::sink>(
+        "Computer Wars", "CasualYouTuber31", "", true,
+        std::make_shared<System::Properties>());
 #endif
-    engine::logger rootLogger("main");
-    awe::game_engine engine;
+    engine::logger rootLogger({ sink, "main" });
+    awe::game_engine engine({ sink, "engine" });
     {
         // Find assets folder path from command-line arguments.
         std::string assetsFolder = "./assets";

--- a/sfx/include/audio.hpp
+++ b/sfx/include/audio.hpp
@@ -112,11 +112,10 @@ namespace sfx {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "audio."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		audio(const std::string& name = "audio") noexcept;
+		audio(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Retrieves the base volume of all audio objects.

--- a/sfx/include/fonts.hpp
+++ b/sfx/include/fonts.hpp
@@ -37,11 +37,10 @@ namespace sfx {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "fonts."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		fonts(const std::string& name = "fonts") noexcept;
+		fonts(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Accesses a previously loaded \c sf::Font object.

--- a/sfx/include/gui.hpp
+++ b/sfx/include/gui.hpp
@@ -61,12 +61,11 @@ namespace sfx {
 		 *                <em>one</em> instance of \c scripts for every instance of
 		 *                \c gui,</b> as the different \c gui functions belonging
 		 *                to the different instances will conflict with each other.
-		 * @param name    The name to give this particular instantiation within the
-		 *                log file. Defaults to "gui."
+		 * @param data    The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
 		gui(const std::shared_ptr<engine::scripts>& scripts,
-			const std::string& name = "gui") noexcept;
+			const engine::logger::data& data) noexcept;
 
 		/**
 		 * Callback given to \c engine::scripts::registerInterface() to register
@@ -223,7 +222,7 @@ namespace sfx {
 			 * Default constructor.
 			 * By default, a GUI background is a solid colour of black.
 			 */
-			gui_background() noexcept;
+			gui_background() noexcept = default;
 
 			/**
 			 * Initialises the GUI background with a sprite.
@@ -238,7 +237,7 @@ namespace sfx {
 			 * Initialises the GUI background with a solid colour.
 			 * @param colour The colour to set.
 			 */
-			gui_background(sf::Color colour) noexcept;
+			gui_background(const sf::Color& colour) noexcept;
 
 			/**
 			 * Sets this GUI background to be a sprite.
@@ -257,7 +256,7 @@ namespace sfx {
 			 * The stored sprite ID is then ignored.
 			 * @param colour The colour to set.
 			 */
-			void set(sf::Color colour) noexcept;
+			void set(const sf::Color& colour) noexcept;
 
 			/**
 			 * Retrieves the type of this GUI background.

--- a/sfx/include/renderer.hpp
+++ b/sfx/include/renderer.hpp
@@ -363,11 +363,10 @@ namespace sfx {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "renderer."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		renderer(const std::string& name = "renderer") noexcept;
+		renderer(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Opens the render window using configurations.

--- a/sfx/include/texture.hpp
+++ b/sfx/include/texture.hpp
@@ -39,11 +39,10 @@ namespace sfx {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "spritesheet."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		animated_spritesheet(const std::string& name = "spritesheet") noexcept;
+		animated_spritesheet(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Determines whether or not a sprite with a given ID exists in this sheet.
@@ -185,26 +184,27 @@ namespace sfx {
 		 * Initialises the internal logger object.
 		 * \c _sheet will be initialised with \c nullptr, so it should be set later
 		 * on with \c setSpritesheet() if this constructor is used.
-		 * @param  name The name to give this particular instantiation within the
-		 *              log file. Defaults to "sprite."
-		 * @sa     \c engine::logger
+		 * @param data The data to initialise the logger object with. Defaults to
+		 *             the data that represents "no logger."
+		 * @sa    \c engine::logger
 		 */
-		animated_sprite(const std::string& name = "sprite") noexcept;
+		animated_sprite(const engine::logger::data& data = { nullptr, "" })
+			noexcept;
 
 		/**
 		 * Constructs an animated sprite and initialises the internal logger
 		 * object.
-		 * @param  sheet  A pointer to an \c animated_spritesheet object containing
-		 *                the sprite to animate.
-		 * @param  sprite The name of the sprite from the given sheet which is to
-		 *                be animated/drawn.
-		 * @param  name   The name to give this particular instantiation within the
-		 *                log file. Defaults to "sprite."
-		 * @sa     \c engine::logger
+		 * @param sheet  A pointer to an \c animated_spritesheet object containing
+		 *               the sprite to animate.
+		 * @param sprite The name of the sprite from the given sheet which is to be
+		 *               animated/drawn.
+		 * @param data   The data to initialise the logger object with. Defaults to
+		 *               the data that represents "no logger."
+		 * @sa    \c engine::logger
 		 */
 		animated_sprite(std::shared_ptr<const sfx::animated_spritesheet> sheet,
-			const std::string& sprite, const std::string& name = "sprite")
-			noexcept;
+			const std::string& sprite, const engine::logger::data& data =
+			{ nullptr, "" }) noexcept;
 
 		/**
 		 * Sets a new \c animated_spritesheet to this animated sprite.

--- a/sfx/include/userinput.hpp
+++ b/sfx/include/userinput.hpp
@@ -310,11 +310,10 @@ namespace sfx {
 	public:
 		/**
 		 * Initialises the internal logger object.
-		 * @param name The name to give this particular instantiation within the
-		 *             log file. Defaults to "user_input."
+		 * @param data The data to initialise the logger object with.
 		 * @sa    \c engine::logger
 		 */
-		user_input(const std::string& name = "user_input") noexcept;
+		user_input(const engine::logger::data& data) noexcept;
 
 		/**
 		 * Returns a set of controls that have been registered with this object.

--- a/sfx/source/audio.cpp
+++ b/sfx/source/audio.cpp
@@ -24,7 +24,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const float sfx::audio::_granularity = 100.0f;
 
-sfx::audio::audio(const std::string& name) noexcept : _logger(name) {}
+sfx::audio::audio(const engine::logger::data& data) noexcept :
+	json_script({data.sink, "json_script"}), _logger(data) {}
 
 float sfx::audio::getVolume() const noexcept {
 	return _volume;

--- a/sfx/source/fonts.cpp
+++ b/sfx/source/fonts.cpp
@@ -22,7 +22,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "fonts.hpp"
 
-sfx::fonts::fonts(const std::string& name) noexcept : _logger(name) {}
+sfx::fonts::fonts(const engine::logger::data& data) noexcept :
+	json_script({data.sink, "json_script"}), _logger(data) {}
 
 std::shared_ptr<sf::Font> sfx::fonts::operator[](const std::string& key) const
 	noexcept {

--- a/sfx/source/gui.cpp
+++ b/sfx/source/gui.cpp
@@ -23,6 +23,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "gui.hpp"
 #include "fmtformatter.hpp"
 
+#undef MessageBox
+
 using namespace tgui;
 
 // These values are intended to be constant.
@@ -33,15 +35,13 @@ sf::Color NO_COLOUR(0, 0, 0, 0);
 // GUI_BACKGROUND //
 ////////////////////
 
-sfx::gui::gui_background::gui_background() noexcept {}
-
 sfx::gui::gui_background::gui_background(
 	const std::shared_ptr<const sfx::animated_spritesheet>& sheet,
 	const std::string& key) noexcept {
 	set(sheet, key);
 }
 
-sfx::gui::gui_background::gui_background(sf::Color colour) noexcept {
+sfx::gui::gui_background::gui_background(const sf::Color& colour) noexcept {
 	set(colour);
 }
 
@@ -53,7 +53,7 @@ void sfx::gui::gui_background::set(
 	_bgSprite.setSprite(key);
 }
 
-void sfx::gui::gui_background::set(sf::Color colour) noexcept {
+void sfx::gui::gui_background::set(const sf::Color& colour) noexcept {
 	_flag = sfx::gui::gui_background::type::Colour;
 	_bgColour.setFillColor(colour);
 }
@@ -127,7 +127,8 @@ CScriptAny* sfx::gui::CScriptAnyWrapper::operator->() const noexcept {
 /////////
 
 sfx::gui::gui(const std::shared_ptr<engine::scripts>& scripts,
-	const std::string& name) noexcept : _scripts(scripts), _logger(name) {
+	const engine::logger::data& data) noexcept :
+	json_script({data.sink, "json_script"}), _scripts(scripts), _logger(data) {
 	if (!scripts) {
 		_logger.error("No scripts object has been provided to this GUI object: no "
 			"menus will be loaded.");
@@ -791,7 +792,7 @@ void sfx::gui::_animate(const sf::RenderTarget& target, const double scaling,
 			std::dynamic_pointer_cast<BitmapButton>(widget)->
 				setImage(blank);
 		} else if (type == "Picture") {
-			auto picture = std::dynamic_pointer_cast<Picture>(widget);
+			auto picture = std::dynamic_pointer_cast<tgui::Picture>(widget);
 			picture->getRenderer()->setTexture(blank);
 			if (_dontOverridePictureSizeWithSpriteSize.find(widgetName)
 				== _dontOverridePictureSizeWithSpriteSize.end()) {
@@ -861,8 +862,8 @@ void sfx::gui::_animate(const sf::RenderTarget& target, const double scaling,
 					newPosition = std::dynamic_pointer_cast<BitmapButton>(widget)->
 						getAbsolutePositionOfImage();
 				} else if (type == "Picture") {
-					newPosition = std::dynamic_pointer_cast<Picture>(widget)->
-						getAbsolutePosition();
+					newPosition = std::dynamic_pointer_cast<tgui::Picture>(widget)
+						->getAbsolutePosition();
 				}
 				animatedSprite.setPosition(newPosition);
 			} else if (_guiSpriteKeys.find(widgetName) != _guiSpriteKeys.end() &&
@@ -937,7 +938,7 @@ void sfx::gui::_translateWidget(tgui::Widget::Ptr widget) noexcept {
 			// separately to keep this as simple as possible. Potentially multiple
 			// menu hierarchies would have to be stored, though...
 		} else if (type == "MessageBox") {
-			auto w = _findWidget<MessageBox>(widgetName);
+			auto w = _findWidget<tgui::MessageBox>(widgetName);
 			w->setTitle(_getTranslatedText(widgetName, 0));
 			w->setText(_getTranslatedText(widgetName, 1));
 			// Don't know how I'm going to translate buttons.

--- a/sfx/source/renderer.cpp
+++ b/sfx/source/renderer.cpp
@@ -76,7 +76,8 @@ bool sfx::isWindowMaximised(const sf::WindowHandle window,
 #endif
 }
 
-sfx::renderer::renderer(const std::string& name) noexcept : _logger(name) {}
+sfx::renderer::renderer(const engine::logger::data& data) noexcept :
+	json_script({ data.sink, "json_script" }), _logger(data) {}
 
 void sfx::renderer::openWindow() noexcept {
 	sf::VideoMode mode(_settings.width, _settings.height);

--- a/sfx/source/texture.cpp
+++ b/sfx/source/texture.cpp
@@ -22,8 +22,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "texture.hpp"
 
-sfx::animated_spritesheet::animated_spritesheet(const std::string& name) noexcept :
-	_logger(name) {}
+sfx::animated_spritesheet::animated_spritesheet(const engine::logger::data& data)
+	noexcept : json_script({ data.sink, "json_script" }), _logger(data) {}
 
 const sf::Texture& sfx::animated_spritesheet::getTexture() const noexcept {
 	return _texture;
@@ -159,12 +159,13 @@ bool sfx::animated_spritesheet::_save(nlohmann::ordered_json& j) noexcept {
 	return false;
 }
 
-sfx::animated_sprite::animated_sprite(const std::string& name) noexcept :
-	_logger(name) {}
+sfx::animated_sprite::animated_sprite(const engine::logger::data& data) noexcept :
+	_logger(data) {}
 
 sfx::animated_sprite::animated_sprite(
 	std::shared_ptr<const sfx::animated_spritesheet> sheet,
-	const std::string& sprite, const std::string& name) noexcept : _logger(name) {
+	const std::string& sprite, const engine::logger::data& data) noexcept :
+	_logger(data) {
 	setSpritesheet(sheet);
 	setSprite(sprite);
 }

--- a/sfx/source/userinput.cpp
+++ b/sfx/source/userinput.cpp
@@ -107,7 +107,8 @@ sfx::control_signal sfx::convert::tosignaltype(unsigned int s,
 	return static_cast<sfx::control_signal>(s);
 }
 
-sfx::user_input::user_input(const std::string& name) noexcept : _logger(name) {}
+sfx::user_input::user_input(const engine::logger::data& data) noexcept :
+	json_script({data.sink, "json_script"}), _logger(data) {}
 
 std::unordered_set<std::string> sfx::user_input::getControls() const noexcept {
 	std::unordered_set<std::string> ret;


### PR DESCRIPTION
:hammer: All objects with loggers now accept a sink parameter as well as a name
:sparkles: Objects can now be configured to not log anything
:stethoscope: Document logger exception safety
:fire: Remove dialogue code from build, for now
:memo: Fix ~scripts() doc comment inaccuracy
:zap: gui_background now accepts references to Color objects and not copies
:no_entry: Resolve MessageBox and Picture conflicts in gui.cpp